### PR TITLE
Generic patches, removing the x86CPU check error and also the error after wx compiles.

### DIFF
--- a/Source/Core/Common/x64CPUDetect.cpp
+++ b/Source/Core/Common/x64CPUDetect.cpp
@@ -42,10 +42,10 @@ static inline void __cpuid(int info[4], int function_id)
 }
 
 #endif  // ifndef _WIN32
-u64 _xgetbv(u32 index)	
+static u64 _xgetbv(u32 index)	
 #ifdef _WIN32
 
-u64 xgetbv(u32 index)
+static u64 xgetbv(u32 index)
 {
   return _xgetbv(index);
 }
@@ -53,7 +53,7 @@ constexpr u32 XCR_XFEATURE_ENABLED_MASK = _XCR_XFEATURE_ENABLED_MASK;
 
 #else
 
-u64 xgetbv(u32 index)
+static u64 xgetbv(u32 index)
 {
 	u32 eax, edx;
 	__asm__ __volatile__("xgetbv" : "=a"(eax), "=d"(edx) : "c"(index));

--- a/Source/Core/Common/x64CPUDetect.cpp
+++ b/Source/Core/Common/x64CPUDetect.cpp
@@ -42,7 +42,7 @@ static inline void __cpuid(int info[4], int function_id)
 }
 
 #endif  // ifndef _WIN32
-static u64 _xgetbv(u32 index);	
+static u64 xgetbv(u32 index);	
 #ifdef _WIN32
 
 static u64 xgetbv(u32 index)

--- a/Source/Core/Common/x64CPUDetect.cpp
+++ b/Source/Core/Common/x64CPUDetect.cpp
@@ -53,7 +53,7 @@ constexpr u32 XCR_XFEATURE_ENABLED_MASK = _XCR_XFEATURE_ENABLED_MASK;
 
 #else
 
-static u64 xgetbv(u32 index)
+static u64 xgetbv(u32 index);
 {
 	u32 eax, edx;
 	__asm__ __volatile__("xgetbv" : "=a"(eax), "=d"(edx) : "c"(index));

--- a/Source/Core/Common/x64CPUDetect.cpp
+++ b/Source/Core/Common/x64CPUDetect.cpp
@@ -42,10 +42,10 @@ static inline void __cpuid(int info[4], int function_id)
 }
 
 #endif  // ifndef _WIN32
-static u64 _xgetbv(u32 index)	
+u64 _xgetbv(u32 index)	
 #ifdef _WIN32
 
-static u64 xgetbv(u32 index)
+u64 xgetbv(u32 index)
 {
   return _xgetbv(index);
 }
@@ -53,7 +53,7 @@ constexpr u32 XCR_XFEATURE_ENABLED_MASK = _XCR_XFEATURE_ENABLED_MASK;
 
 #else
 
-static u64 xgetbv(u32 index)
+u64 xgetbv(u32 index)
 {
 	u32 eax, edx;
 	__asm__ __volatile__("xgetbv" : "=a"(eax), "=d"(edx) : "c"(index));

--- a/Source/Core/Common/x64CPUDetect.cpp
+++ b/Source/Core/Common/x64CPUDetect.cpp
@@ -60,7 +60,7 @@ static u64 xgetbv(u32 index)
 	return ((u64)edx << 32) | eax;
 }
 constexpr u32 XCR_XFEATURE_ENABLED_MASK = 0;
-#endif  // ifndef _WIN32	#endif  // ifdef
+#endif  // ifdef
 
 CPUInfo cpu_info;
 

--- a/Source/Core/Common/x64CPUDetect.cpp
+++ b/Source/Core/Common/x64CPUDetect.cpp
@@ -42,7 +42,7 @@ static inline void __cpuid(int info[4], int function_id)
 }
 
 #endif  // ifndef _WIN32
-static u64 _xgetbv(u32 index)	
+static u64 _xgetbv(u32 index);	
 #ifdef _WIN32
 
 static u64 xgetbv(u32 index)

--- a/Source/Core/Common/x64CPUDetect.cpp
+++ b/Source/Core/Common/x64CPUDetect.cpp
@@ -53,7 +53,7 @@ constexpr u32 XCR_XFEATURE_ENABLED_MASK = _XCR_XFEATURE_ENABLED_MASK;
 
 #else
 
-static u64 _xgetbv(u32 index)
+static u64 xgetbv(u32 index)
 {
 	u32 eax, edx;
 	__asm__ __volatile__("xgetbv" : "=a"(eax), "=d"(edx) : "c"(index));

--- a/Source/Core/Common/x64CPUDetect.cpp
+++ b/Source/Core/Common/x64CPUDetect.cpp
@@ -60,7 +60,7 @@ static u64 xgetbv(u32 index)
 	return ((u64)edx << 32) | eax;
 }
 constexpr u32 XCR_XFEATURE_ENABLED_MASK = 0;
-#endif  // ifdef
+#endif  // ifdef _WIN32
 
 CPUInfo cpu_info;
 

--- a/Source/Core/Common/x64CPUDetect.cpp
+++ b/Source/Core/Common/x64CPUDetect.cpp
@@ -53,7 +53,7 @@ constexpr u32 XCR_XFEATURE_ENABLED_MASK = _XCR_XFEATURE_ENABLED_MASK;
 
 #else
 
-static u64 xgetbv(u32 index);
+static u64 _xgetbv(u32 index)
 {
 	u32 eax, edx;
 	__asm__ __volatile__("xgetbv" : "=a"(eax), "=d"(edx) : "c"(index));

--- a/Source/Core/Common/x64CPUDetect.cpp
+++ b/Source/Core/Common/x64CPUDetect.cpp
@@ -145,7 +145,7 @@ void CPUInfo::Detect()
 		//  - XGETBV result has the XCR bit set.
 		if (((cpu_id[2] >> 28) & 1) && ((cpu_id[2] >> 27) & 1))
 		{
-			if ((xgetbv(XCR_XFEATURE_ENABLED_MASK) & 0x6) == 0x6)
+			if ((_xgetbv(XCR_XFEATURE_ENABLED_MASK) & 0x6) == 0x6)
 			{
 				bAVX = true;
 				if ((cpu_id[2] >> 12) & 1)

--- a/Source/Core/Common/x64CPUDetect.cpp
+++ b/Source/Core/Common/x64CPUDetect.cpp
@@ -60,7 +60,7 @@ static u64 xgetbv(u32 index)
 	return ((u64)edx << 32) | eax;
 }
 constexpr u32 XCR_XFEATURE_ENABLED_MASK = 0;
-#endif  // ifdef _WIN32
+#endif // ifdef _WIN32
 
 CPUInfo cpu_info;
 

--- a/Source/Core/Common/x64CPUDetect.cpp
+++ b/Source/Core/Common/x64CPUDetect.cpp
@@ -41,15 +41,26 @@ static inline void __cpuid(int info[4], int function_id)
 	return __cpuidex(info, function_id, 0);
 }
 
-#define _XCR_XFEATURE_ENABLED_MASK 0
-static u64 _xgetbv(u32 index)
+#endif  // ifndef _WIN32
+static u64 _xgetbv(u32 index)	
+#ifdef _WIN32
+
+static u64 xgetbv(u32 index)
+{
+  return _xgetbv(index);
+}
+constexpr u32 XCR_XFEATURE_ENABLED_MASK = _XCR_XFEATURE_ENABLED_MASK;
+
+#else
+
+static u64 xgetbv(u32 index)
 {
 	u32 eax, edx;
 	__asm__ __volatile__("xgetbv" : "=a"(eax), "=d"(edx) : "c"(index));
 	return ((u64)edx << 32) | eax;
 }
-
-#endif // ifndef _WIN32
+constexpr u32 XCR_XFEATURE_ENABLED_MASK = 0;
+#endif  // ifndef _WIN32	#endif  // ifdef
 
 CPUInfo cpu_info;
 
@@ -134,7 +145,7 @@ void CPUInfo::Detect()
 		//  - XGETBV result has the XCR bit set.
 		if (((cpu_id[2] >> 28) & 1) && ((cpu_id[2] >> 27) & 1))
 		{
-			if ((_xgetbv(_XCR_XFEATURE_ENABLED_MASK) & 0x6) == 0x6)
+			if ((xgetbv(XCR_XFEATURE_ENABLED_MASK) & 0x6) == 0x6)
 			{
 				bAVX = true;
 				if ((cpu_id[2] >> 12) & 1)

--- a/Source/Core/VideoBackends/OGL/RasterFont.cpp
+++ b/Source/Core/VideoBackends/OGL/RasterFont.cpp
@@ -15,12 +15,12 @@
 namespace OGL
 {
 
-static const int _CHAR_WIDTH = 8;
-static const int _CHAR_HEIGHT = 13;
-static const int _CHAR_OFFSET = 32;
-static const int _CHAR_COUNT = 95;
+static const int _CHARACTER_WIDTH = 8;
+static const int _CHARACTER_HEIGHT = 13;
+static const int _CHARACTER_OFFSET = 32;
+static const int _CHARACTER_COUNT = 95;
 
-static const u8 rasters[_CHAR_COUNT][_CHAR_HEIGHT] = {
+static const u8 rasters[_CHARACTER_COUNT][_CHARACTER_HEIGHT] = {
 	{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
 	{0x00, 0x00, 0x18, 0x18, 0x00, 0x00, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18},
 	{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x36, 0x36, 0x36, 0x36},
@@ -146,27 +146,29 @@ RasterFont::RasterFont()
 	glGenTextures(1, &texture);
 	glActiveTexture(GL_TEXTURE8);
 	glBindTexture(GL_TEXTURE_2D, texture);
-	std::vector<u32> texture_data(_CHAR_WIDTH * _CHAR_COUNT * _CHAR_HEIGHT);
-	for (int y = 0; y < _CHAR_HEIGHT; y++)
+	std::vector<u32> texture_data(_CHARACTER_WIDTH * _CHARACTER_COUNT * _CHARACTER_HEIGHT);
+	for (int y = 0; y < _CHARACTER_HEIGHT; y++)
 	{
-		for (int c = 0; c < _CHAR_COUNT; c++)
+		for (int c = 0; c < _CHARACTER_COUNT; c++)
 		{
-			for (int x = 0; x < _CHAR_WIDTH; x++)
+			for (int x = 0; x < _CHARACTER_WIDTH; x++)
 			{
-				bool pixel = (0 != (rasters[c][y] & (1 << (_CHAR_WIDTH - x - 1))));
-				texture_data[_CHAR_WIDTH * _CHAR_COUNT * y + _CHAR_WIDTH * c + x] = pixel ? -1 : 0;
+				        bool pixel = (0 != (rasters[c][y] & (1 << (CHARACTER_WIDTH - x - 1))));
+        				texture_data[CHAR_WIDTH * CHAR_COUNT * y + CHAR_WIDTH * c + x] = pixel ? -1 : 0;
+					texture_data[CHARACTER_WIDTH * CHARACTER_COUNT * y + CHARACTER_WIDTH * c + x] =
+            				    pixel ? -1 : 0;
 			}
 		}
 	}
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
-	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, _CHAR_WIDTH * _CHAR_COUNT, _CHAR_HEIGHT, 0, GL_RGBA, GL_UNSIGNED_BYTE, texture_data.data());
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, _CHARACTER_WIDTH * _CHARACTER_COUNT, _CHARACTER_HEIGHT, 0, GL_RGBA, GL_UNSIGNED_BYTE, texture_data.data());
 
 	// generate shader
 	ProgramShaderCache::CompileShader(s_shader, s_vertexShaderSrc, s_fragmentShaderSrc);
 	s_shader.Bind();
 
 	// bound uniforms
-	glUniform2f(glGetUniformLocation(s_shader.glprogid,"charSize"), 1.0f / GLfloat(_CHAR_COUNT), 1.0f);
+	glUniform2f(glGetUniformLocation(s_shader.glprogid,"charSize"), 1.0f / GLfloat(_CHARACTER_COUNT), 1.0f);
 	uniform_color_id = glGetUniformLocation(s_shader.glprogid,"color");
 	glUniform4f(uniform_color_id, 1.0f, 1.0f, 1.0f, 1.0f);
 	uniform_offset_id = glGetUniformLocation(s_shader.glprogid, "offset");
@@ -196,8 +198,8 @@ void RasterFont::printMultilineText(const std::string& text, double start_x, dou
 	std::vector<GLfloat> vertices(text.length() * 6 * 4);
 
 	int usage = 0;
-	GLfloat delta_x = GLfloat(2 * _CHAR_WIDTH) / GLfloat(bbWidth);
-	GLfloat delta_y = GLfloat(2 * _CHAR_HEIGHT) / GLfloat(bbHeight);
+	GLfloat delta_x = GLfloat(2 * _CHARACTER_WIDTH) / GLfloat(bbWidth);
+	GLfloat delta_y = GLfloat(2 * _CHARACTER_HEIGHT) / GLfloat(bbHeight);
 	GLfloat border_x = 2.0f / GLfloat(bbWidth);
 	GLfloat border_y = 4.0f / GLfloat(bbHeight);
 
@@ -220,37 +222,37 @@ void RasterFont::printMultilineText(const std::string& text, double start_x, dou
 			continue;
 		}
 
-		if (c < _CHAR_OFFSET || c >= _CHAR_COUNT + _CHAR_OFFSET)
+		if (c < _CHARACTER_OFFSET || c >= _CHARACTER_COUNT + _CHARACTER_OFFSET)
 			continue;
 
 		vertices[usage++] = x;
 		vertices[usage++] = y;
-		vertices[usage++] = GLfloat(c - _CHAR_OFFSET);
+		vertices[usage++] = GLfloat(c - _CHARACTER_OFFSET);
 		vertices[usage++] = 0.0f;
 
 		vertices[usage++] = x + delta_x;
 		vertices[usage++] = y;
-		vertices[usage++] = GLfloat(c - _CHAR_OFFSET + 1);
+		vertices[usage++] = GLfloat(c - _CHARACTER_OFFSET + 1);
 		vertices[usage++] = 0.0f;
 
 		vertices[usage++] = x + delta_x;
 		vertices[usage++] = y + delta_y;
-		vertices[usage++] = GLfloat(c - _CHAR_OFFSET + 1);
+		vertices[usage++] = GLfloat(c - _CHARACTER_OFFSET + 1);
 		vertices[usage++] = 1.0f;
 
 		vertices[usage++] = x;
 		vertices[usage++] = y;
-		vertices[usage++] = GLfloat(c - _CHAR_OFFSET);
+		vertices[usage++] = GLfloat(c - _CHARACTER_OFFSET);
 		vertices[usage++] = 0.0f;
 
 		vertices[usage++] = x + delta_x;
 		vertices[usage++] = y + delta_y;
-		vertices[usage++] = GLfloat(c - _CHAR_OFFSET + 1);
+		vertices[usage++] = GLfloat(c - _CHARACTER_OFFSET + 1);
 		vertices[usage++] = 1.0f;
 
 		vertices[usage++] = x;
 		vertices[usage++] = y + delta_y;
-		vertices[usage++] = GLfloat(c - _CHAR_OFFSET);
+		vertices[usage++] = GLfloat(c - _CHARACTER_OFFSET);
 		vertices[usage++] = 1.0f;
 
 		x += delta_x + border_x;


### PR DESCRIPTION
One section within the VideoBackend part of the edit that I do worry about, but I feel that it will work.
All patches can be found here: https://forums.dolphin-emu.org/Thread-linux-unable-to-compile-5-0-release-of-dolphin