### PR TITLE
Add Mac Support

### DIFF
--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -192,7 +192,7 @@ namespace Movie {
 	    std::string iniContent;
 
 	    bool success =
-	        File::ReadFileToString(SYSDATA_DIR "/InfoDisplay/" + gameID + ".ini", iniContent);
+	        File::ReadFileToString(File::GetSysDirectory() + "/InfoDisplay/" + gameID + ".ini", iniContent);
 
 	    if (success)
 	    {

--- a/Source/Core/DolphinWX/LaunchLuaScript.cpp
+++ b/Source/Core/DolphinWX/LaunchLuaScript.cpp
@@ -152,7 +152,7 @@ void LuaWindow::Shown()
 	m_choice_script->Clear();
 
 	//Find all Lua files
-	std::vector<std::string> rFilenames = DoFileSearch({".lua"}, {SYSDATA_DIR "/Scripts" });
+	std::vector<std::string> rFilenames = DoFileSearch({".lua"}, {File::GetSysDirectory() + "/Scripts" });
 
 	if (rFilenames.size() > 0)
 	{


### PR DESCRIPTION
Use `File::GetSysDirectory()` instead of `SYSDATA_DIR` to find the sys folder as `File::GetSysDirectory()` seems to properly find the sys folder on MacOS