### PR TITLE
Define _xgetbv_fix for windows

### DIFF
--- a/Source/Core/Common/x64CPUDetect.cpp
+++ b/Source/Core/Common/x64CPUDetect.cpp
@@ -49,6 +49,12 @@ static u64 _xgetbv_fix(u32 index)
 	return ((u64)edx << 32) | eax;
 }
 
+#else
+// Define _xgetbv_fix for windows
+static u64 _xgetbv_fix(u32 index)
+{
+	return _xgetbv(index)
+}
 #endif // ifndef _WIN32
 
 CPUInfo cpu_info;


### PR DESCRIPTION
This is needed to allow building on Windows and Linux, as long as I didn't mess something up